### PR TITLE
added hash hash creation and check for authorization

### DIFF
--- a/Minitwit_BE/Minitwit_BE.DomainService/UserDomainService.cs
+++ b/Minitwit_BE/Minitwit_BE.DomainService/UserDomainService.cs
@@ -2,6 +2,8 @@
 using Minitwit_BE.Domain.Exceptions;
 using Minitwit_BE.DomainService.Interfaces;
 using Minitwit_BE.Persistence;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Minitwit_BE.DomainService
 {
@@ -25,21 +27,38 @@ namespace Minitwit_BE.DomainService
             }
             else
             {
+                user.PwHash = GetHash(user.PwHash);
                 await _persistenceService.AddUser(user);
             }
         }
 
         public async Task<int> Login(User user)
         {
-            var loggedUser = (await _persistenceService.GetUsers(
-                u => u.Email.Equals(user.Email) && u.PwHash.Equals(user.PwHash))).FirstOrDefault();
-
-            if (loggedUser == null)
+            var loggedUser = (await _persistenceService.GetUsers(u => u.Email.Equals(user.Email))).FirstOrDefault();
+            if (loggedUser != null && CompareHash(user.PwHash, loggedUser.PwHash))
+            {
+                return loggedUser.UserId;
+            }
+            else
             {
                 throw new UnauthorizedAccessException("Email or password does not match!");
             } 
             
-            return loggedUser.UserId;
+        }
+
+        public string GetHash(string password)
+        {
+            string fixedSalt = "7bV6DZ3t8Mwe?n?#";
+            byte[] unhashedBytes = Encoding.Unicode.GetBytes(password + fixedSalt);
+            SHA256 sha256 = SHA256.Create();
+            byte[] hashedBytes = sha256.ComputeHash(unhashedBytes);
+            return Convert.ToBase64String(hashedBytes);
+        }
+
+        public bool CompareHash(string attemptedPassword, string storedPwd)
+        {
+            string base64AttemptedHash = GetHash(attemptedPassword);
+            return storedPwd.Equals(base64AttemptedHash);
         }
     }
 }


### PR DESCRIPTION
Using a fixed salt so that we don't bother about storing it as another user's property in the db. Tested on my setup, would be nice if one person could also verify that.

NOTE: logging in ur old users will return 401 bc their stored password is a pure string, whereas now its a stringified byte array. When comparing it tries to decode the byte array to string, but since ur old user has already a string then it obviously doesn't pass.